### PR TITLE
Activate python-deduckt command console

### DIFF
--- a/deduckt/main.py
+++ b/deduckt/main.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from .deduckt import main
 if __name__ == '__main__':
-    import deduckt
-    deduckt.main()
+    #import deduckt
+    #deduckt.main()
+    pass

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,13 @@ setup(
     url='https://www.metacraft-labs.com',
     packages=find_packages(),
     description=description,
-    long_description=open('README.rst').read(),
+    # long_description=open('README.rst').read(),
     install_requires=open('requirements.txt').read(),
-    entry_points='''
-        [console_scripts]
-        python-deduckt=deduckt.main:cli
-    ''',
+    entry_points={
+      'console_scripts': [
+        'python-deduckt=deduckt.main:main',
+      ],
+    },
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
1.  Enable the console script from setup.py & corrected the function name as expected from console script
2.  Minor adjustment over main.py as it's seen that deduckt module have main *def* which compile the source and generates *ast* - so introduce absolute import and use the *main* function as base of the main.py
3. Currently  ``` if __name__ == '__main__':``` doesn't have used , please suggest if any more concern on it 